### PR TITLE
Relatives Updates

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -195,11 +195,7 @@ class Membership < ActiveRecord::Base
   end
 
   def info
-    if read_attribute(:info).nil?
-      {}
-    else
-      super
-    end
+    (self[:info] || {}).with_indifferent_access
   end
 
   def can_have_relatives?

--- a/app/models/relative.rb
+++ b/app/models/relative.rb
@@ -2,6 +2,8 @@ class Relative < Membership
   belongs_to :family
   accepts_nested_attributes_for :user
 
+  before_validation :strip_invited_email
+
   validate :has_good_family
   validate :no_time_traveling
 
@@ -10,6 +12,10 @@ class Relative < Membership
   end
 
   private
+
+    def strip_invited_email
+      info.dig(:invited_email)&.strip!
+    end
 
     def has_good_family
       errors.add(:family_id, 'must have a family association') if family_id.nil?

--- a/spec/controllers/relatives_controller_spec.rb
+++ b/spec/controllers/relatives_controller_spec.rb
@@ -36,22 +36,6 @@ RSpec.describe RelativesController, type: :controller do
   # RelativesController. Be sure to keep this updated too.
   let(:valid_session) { {} }
 
-  skip 'GET index' do
-    it 'assigns all relatives as @relatives' do
-      relative = Relative.create! valid_attributes
-      get :index, {}, valid_session
-      expect(assigns(:relatives)).to eq([relative])
-    end
-  end
-
-  skip 'GET show' do
-    it 'assigns the requested relative as @relative' do
-      relative = Relative.create! valid_attributes
-      get :show, {id: relative.to_param}, valid_session
-      expect(assigns(:relative)).to eq(relative)
-    end
-  end
-
   skip 'GET new' do
     it 'assigns a new relative as @relative' do
       get :new, {}, valid_session
@@ -100,45 +84,7 @@ RSpec.describe RelativesController, type: :controller do
     end
   end
 
-  skip 'PUT update' do
-    skip 'with valid params' do
-      let(:new_attributes) {
-        skip('Add a hash of attributes valid for your model')
-      }
-
-      it 'updates the requested relative' do
-        relative = Relative.create! valid_attributes
-        put :update, {id: relative.to_param, relative: new_attributes}, valid_session
-        relative.reload
-        skip('Add assertions for updated state')
-      end
-
-      it 'assigns the requested relative as @relative' do
-        relative = Relative.create! valid_attributes
-        put :update, {id: relative.to_param, relative: valid_attributes}, valid_session
-        expect(assigns(:relative)).to eq(relative)
-      end
-
-      it 'redirects to the relative' do
-        relative = Relative.create! valid_attributes
-        put :update, {id: relative.to_param, relative: valid_attributes}, valid_session
-        expect(response).to redirect_to(relative)
-      end
-    end
-
-    skip 'with invalid params' do
-      it 'assigns the relative as @relative' do
-        relative = Relative.create! valid_attributes
-        put :update, {id: relative.to_param, relative: invalid_attributes}, valid_session
-        expect(assigns(:relative)).to eq(relative)
-      end
-
-      it "re-renders the 'edit' template" do
-        relative = Relative.create! valid_attributes
-        put :update, {id: relative.to_param, relative: invalid_attributes}, valid_session
-        expect(response).to render_template('edit')
-      end
-    end
+  skip 'POST accept_invitation' do
   end
 
   skip 'DELETE destroy' do

--- a/spec/models/relative_spec.rb
+++ b/spec/models/relative_spec.rb
@@ -1,5 +1,11 @@
 require 'spec_helper'
 
 describe Relative do
-  skip "add some examples to (or delete) #{__FILE__}"
+  it 'strips whitespace from an invited email before validation' do
+    relative = Relative.new(info: { invited_email: ' test.email@with-spaces.com ', pending_approval: true })
+
+    relative.valid?
+
+    expect(relative.info[:invited_email]).to eq('test.email@with-spaces.com')
+  end
 end


### PR DESCRIPTION
Addresses #8, strips whitespace from invited Relatives' emails. Added a spec for that particular thing. Also made the RelativesController Spec, while still `skip`ping, at least reflect the methods of the Controller.