### PR TITLE
Fix bug persisting old card; fix bbug ontinuing after error; add ErrorNotifier service

### DIFF
--- a/app/models/concerns/commerce/purchasable.rb
+++ b/app/models/concerns/commerce/purchasable.rb
@@ -23,9 +23,6 @@ module Commerce
 
     def make_stripe_charge(card_id = nil)
       self.stripe_charge_id = Stripe::Charge.create(charge_information(card_id)).id
-    rescue Stripe::StripeError => e
-      logger.error "Stripe error while saving #{self.class.name.humanize} with payment: #{e.message}"
-      errors.add :base, "There was a problem with your credit card: #{e.message}"
     end
 
     # Purchaser must be defined in model
@@ -37,6 +34,7 @@ module Commerce
     def save_with_payment!(card_id = nil)
       return unless ready_to_pay?
 
+      card_id = nil if stripe_card_token.present?
       purchaser.create_or_update_stripe_customer(stripe_card_token)
 
       purchaser.subscribe_to(self) if self.class.include?(Subscribable) && subscribe?

--- a/app/models/concerns/commerce/purchaser.rb
+++ b/app/models/concerns/commerce/purchaser.rb
@@ -10,7 +10,7 @@ module Commerce
 
     def create_or_update_stripe_customer(stripe_card_token = nil)
       if stripe_customer.present?
-        update_payment_method(stripe_card_token).id if stripe_card_token
+        update_payment_method(stripe_card_token) if stripe_card_token
         update_stripe_customer
       else
         create_stripe_customer(stripe_card_token: stripe_card_token)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,11 +25,11 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  has_many :memberships
+  has_many :memberships, autosave: false
 
-  has_many :mot_ms
-  has_many :rev_guesses
-  has_many :pick_ems
+  has_many :mot_ms, autosave: false
+  has_many :rev_guesses, autosave: false
+  has_many :pick_ems, autosave: false
 
   validates :first_name, :last_name, :email, presence: true
   validates :username, presence: true, uniqueness: true, case_sensitive: false

--- a/app/services/error_notifier.rb
+++ b/app/services/error_notifier.rb
@@ -1,0 +1,9 @@
+class ErrorNotifier
+  class << self
+    def notify(error, severity: :error, output: nil)
+      Rails.logger.public_send(severity, "#{error.class}: #{error.message}")
+      Rails.logger.info error.backtrace.to_yaml
+      error.message
+    end
+  end
+end

--- a/app/services/error_notifier.rb
+++ b/app/services/error_notifier.rb
@@ -1,6 +1,6 @@
 class ErrorNotifier
   class << self
-    def notify(error, severity: :error, output: nil)
+    def notify(error, severity: :error)
       Rails.logger.public_send(severity, "#{error.class}: #{error.message}")
       Rails.logger.info error.backtrace.to_yaml
       error.message

--- a/spec/services/error_notifier_spec.rb
+++ b/spec/services/error_notifier_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe ErrorNotifier do
+  describe 'notify' do
+    let(:error) { StandardError.new('This is an error') }
+    it 'outputs the error type and message to logger.error by default' do
+      expect(Rails.logger).to receive(:error).with('StandardError: This is an error')
+      ErrorNotifier.notify(error)
+    end
+
+    it 'outputs the error to logger.warn if directed to' do
+      expect(Rails.logger).to receive(:warn).with('StandardError: This is an error')
+      ErrorNotifier.notify(error, severity: :warn)
+    end
+
+    it 'outputs the backtrace to logger.info' do
+      allow(Rails.logger).to receive(:info) do |output|
+        expect { YAML.load(output) }.not_to raise_error
+        expect(YAML.load(output)).not_to be(false)
+      end
+
+      ErrorNotifier.notify(error)
+    end
+  end
+end


### PR DESCRIPTION
#37 revealed that we were trying to charge an old card if a user added a new card and purchased a membership: it went like this:

- User chooses "Change Card," enters new card info, submits
- Create method receives both stripe_card_token and card_id (because old card still existed on the form)
- Both are passed to `save_with_payment!`
- A new card is created, all other cards are destroyed
- card_id is passed along if present (it is, and it represents the now-destroyed original card)

The next issue is that rather than seeing the error, users were being allowed to continue. We were even getting notified of new memberships. This is because validation would be _re-applied_ with `save!` so the error we added to `:base` with the StripeError got wiped out and everything went along just fine. I've removed the `catch` that caught the StripeError and applied a `:base` error; now the StripeError bubbles up to the `save!` call, which in turn bubbles up to the Controller, which catches it and redisplays the "new" page. Still need more feature specs there, but just our luck we've had three people _today_ stumble across this bug so let's get this in.

Also added an `ErrorNotifier` service (with specs!) since we're doing the same few things almost everywhere and this will let us do more with errors in the future if we want. For now it just extracts a few lines of repeated code. Should be applied throughout.