### PR TITLE
Ignore Webhook events by ID from ENV var

### DIFF
--- a/app/services/stripe_webhook_service.rb
+++ b/app/services/stripe_webhook_service.rb
@@ -8,6 +8,7 @@ class StripeWebhookService
 
   def process
     return @response unless filter_event && customer_token && user
+    return { nothing: true, status: 200 } if ignored?
     public_send(@event[:type].gsub(/[^a-z0-9]+/i, '_'))
     @response
   rescue => e
@@ -78,5 +79,9 @@ class StripeWebhookService
 
   def subscription_year
     Time.zone.at(object[:lines][:data][0][:period][:start].to_i).year
+  end
+
+  def ignored?
+    ENV['IGNORED_STRIPE_EVENT_IDS'].to_s.split(/\s*,\s*/).include? @event[:id]
   end
 end

--- a/spec/support/stripe_helper.rb
+++ b/spec/support/stripe_helper.rb
@@ -14,6 +14,10 @@ class StripeHelper
       'ch_' + chars
     end
 
+    def event_id
+      'evt_' + chars
+    end
+
     def chars(n = 24)
       FFaker::Lorem.characters(n)
     end


### PR DESCRIPTION
Because of a prior bug we've got a Webhook that's just pinging and pinging and getting a 500 because it should be handled but won't be because of that bug. The issue that caused the bug is fixed but the Webhook keeps pinging. This is a way to add event IDs to Heroku's ENV vars to explicitly OK an event.