### PR TITLE
Use consistent new membership year logic

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     parallelism: 3
     docker:
-      - image: circleci/ruby:2.6.6-jessie-node-browsers
+      - image: circleci/ruby:2.6.6-node-browsers
         environment:
           COVERAGE: true
           BUNDLE_PATH: vendor/bundle
@@ -68,7 +68,7 @@ jobs:
             - codeclimate.*.json
   upload-coverage:
     docker:
-      - image: circleci/ruby:2.5.1-stretch-node
+      - image: circleci/ruby:2.6.6-node
     environment:
       CC_TEST_REPORTER_ID: c3ff91e23ea0fea718bb62dae0a8a5440dc082d5d2bb508af6b33d0babac479a
     working_directory: ~/bikeindex/bike_index

--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -115,7 +115,7 @@ class MembershipsController < ApplicationController
   end
 
   def prepare_new_form
-    @year = Date.current.month > 10 ? Date.current.year + 1 : Date.current.year
+    @year = Membership.new_membership_year
     @cards = @user.stripe_customer.cards.data if @user.stripe_customer.present?
   end
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -105,12 +105,16 @@ class Membership < ActiveRecord::Base
     %w(Individual Family Relative).map { |type| "#{type}: #{breakdown[[season, type]] || 0}" }.join(' | ')
   end
 
+  def self.new_membership_year
+    Date.current.month > 10 ? Date.current.year + 1 : Date.current.year
+  end
+  
   def self.price
     '1061'
   end
-
+  
   private
-
+  
   def paid_for?
     return true if is_a?(Relative) || overriding_admin.present?
     super

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -112,7 +112,7 @@ class User < ActiveRecord::Base
 
   # Grants a +Membership+ for the current year. Part of import.
   def grant_membership!(type: 'Individual', privileges: [], granted_by: nil, family_id: nil)
-    membership = memberships.where(year: Time.current.year).first_or_initialize
+    membership = memberships.where(year: Membership.new_membership_year).first_or_initialize
     membership.override ||= granted_by
     membership.privileges = privileges
     membership.type ||= type.titleize


### PR DESCRIPTION
When a user created a new membership, it would be assigned to next year if the month is November or December. But UsersController#import, for imports of users who signed up in the tailgate lots, it was always just the current year. This centralizes the logic to behave the former way in both spots.
