### PR TITLE
Stripe updates and fixes

### DIFF
--- a/Dev.dockerfile
+++ b/Dev.dockerfile
@@ -26,6 +26,7 @@ RUN apk add --no-cache --virtual \
     corepack enable
 
 WORKDIR /tmp
+RUN gem install debase-ruby_core_source
 COPY Gemfile Gemfile.lock /tmp/
 RUN gem install foreman && \
   bundle install

--- a/app/controllers/exceptions_controller.rb
+++ b/app/controllers/exceptions_controller.rb
@@ -7,5 +7,7 @@ class ExceptionsController < ActionController::Base
     @status = exception ? ActionDispatch::ExceptionWrapper.new(request.env, exception).try(:status_code) : request.env["PATH_INFO"][1..-1].to_i
     # => Server Response ("Not Found" etc)
     @response = ActionDispatch::ExceptionWrapper.rescue_responses[exception.class.name]
+
+    render template: 'exceptions/show', status: @status, formats: %i[html]
   end
 end

--- a/app/models/concerns/commerce/purchaser.rb
+++ b/app/models/concerns/commerce/purchaser.rb
@@ -19,7 +19,7 @@ module Commerce
 
     def refund(purchase)
       return unless purchase.stripe_charge_id.present?
-      Stripe::Charge.retrieve(purchase.stripe_charge_id).refunds.create
+      Stripe::Refund.create({ charge: purchase.stripe_charge_id })
     end
 
     # @return [Stripe::Customer, nil] Stripe customer associated with User

--- a/app/models/concerns/commerce/purchaser.rb
+++ b/app/models/concerns/commerce/purchaser.rb
@@ -40,7 +40,8 @@ module Commerce
     end
 
     def subscribe_to(product)
-      subscription = stripe_customer.subscriptions.create(
+      subscription = Stripe::Subscription.create(
+        customer: stripe_customer,
         plan: product.plan,
         trial_end: product.trial_end
       )

--- a/app/models/concerns/commerce/purchaser.rb
+++ b/app/models/concerns/commerce/purchaser.rb
@@ -19,7 +19,7 @@ module Commerce
 
     def refund(purchase)
       return unless purchase.stripe_charge_id.present?
-      stripe_customer.charges.retrieve(purchase.stripe_charge_id).refunds.create
+      Stripe::Charge.retrieve(purchase.stripe_charge_id).refunds.create
     end
 
     # @return [Stripe::Customer, nil] Stripe customer associated with User

--- a/app/models/concerns/commerce/subscribable.rb
+++ b/app/models/concerns/commerce/subscribable.rb
@@ -9,7 +9,7 @@ module Commerce
     # Cancel current subscription
     def cancel(provide_refund = false)
       return false unless subscription?
-      purchaser.stripe_customer.subscriptions.retrieve(stripe_subscription_id).delete
+      Stripe::Subscription.retrieve(stripe_subscription_id).delete
       update_attribute(:stripe_subscription_id, "Stripe Subscription #{stripe_subscription_id} Canceled")
       refund if provide_refund
     rescue Stripe::StripeError => e

--- a/app/views/users/_register_now.haml
+++ b/app/views/users/_register_now.haml
@@ -16,6 +16,6 @@
       = link_to new_user_membership_path(user), class: 'button large' do
         = icon 'fa-regular', 'credit-card fa-fw'
         Buy a
-        = Date.current.year
+        = Membership.new_membership_year
         Membership
 %hr

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -167,7 +167,7 @@ describe MembershipsController do
           after(:each) { Timecop.return }
 
           before :each do
-            allow_any_instance_of(User).to receive_message_chain(:stripe_customer, :subscriptions, :retrieve) {
+            allow(Stripe::Subscription).to receive(:retrieve) {
               double(
                 'Stripe::Subscription',
                 id: event.dig(:data, :object, :subscription),

--- a/spec/support/shared_examples/purchasable.rb
+++ b/spec/support/shared_examples/purchasable.rb
@@ -148,8 +148,8 @@ shared_examples_for 'Commerce::Purchasable' do
     it 'saves the Stripe::Refund id to the refund attribute' do
       product.update_attribute(:stripe_charge_id, StripeHelper.charge_id)
       refund_id = StripeHelper.refund_id
-      allow(product.purchaser)
-        .to receive_message_chain('stripe_customer.charges.retrieve.refunds.create')
+      allow(Stripe::Refund)
+        .to receive(:create).with({ charge: product.stripe_charge_id })
         .and_return(double('Stripe::Refund', id: refund_id))
 
       expect { product.refund }.to change { product.refunded }.to refund_id
@@ -158,8 +158,8 @@ shared_examples_for 'Commerce::Purchasable' do
     it 'adds an error to :base if there is a Stripe Error' do
       product.update_attribute(:stripe_charge_id, StripeHelper.charge_id)
       error_message = 'The expiration date on your card is not valid'
-      allow(product.purchaser)
-        .to receive_message_chain('stripe_customer.charges.retrieve.refunds.create')
+      allow(Stripe::Refund)
+        .to receive(:create).with({ charge: product.stripe_charge_id })
         .and_raise(Stripe::StripeError.new(error_message))
 
       expect { product.refund }.to change { product.errors[:base] }.to(['There was a problem refunding the transaction.'])

--- a/spec/support/shared_examples/subscribable.rb
+++ b/spec/support/shared_examples/subscribable.rb
@@ -42,7 +42,7 @@ shared_examples_for 'Commerce::Subscribable' do
     end
 
     it 'returns false for having a canceled subscription' do
-      allow(product.purchaser).to receive_message_chain('stripe_customer.subscriptions.retrieve.delete')
+      allow(Stripe::Subscription).to receive(:update).with(/^sub_[a-z0-9]{23}$/, { cancel_at_period_end: true })
 
       stripe_subscription_id = StripeHelper.subscription_id
       product.update_attribute(:stripe_subscription_id, stripe_subscription_id)
@@ -70,13 +70,13 @@ shared_examples_for 'Commerce::Subscribable' do
       before(:each) { product.update_attribute(:stripe_subscription_id, StripeHelper.subscription_id) }
 
       it 'calls delete on the Stripe::Subscription' do
-        expect(product.purchaser).to receive_message_chain('stripe_customer.subscriptions.retrieve.delete')
+        expect(Stripe::Subscription).to receive(:update).with(/^sub_[a-z0-9]{23}$/, { cancel_at_period_end: true })
 
         product.cancel
       end
 
       it 'replaces stripe_subscription_id with "Stripe Subscription [SUBSCRIPTION ID] Canceled"' do
-        allow(product.purchaser).to receive_message_chain('stripe_customer.subscriptions.retrieve.delete')
+        allow(Stripe::Subscription).to receive(:update).with(/^sub_[a-z0-9]{23}$/, { cancel_at_period_end: true })
         sub_id = product.stripe_subscription_id
 
         expect { product.cancel }
@@ -85,7 +85,7 @@ shared_examples_for 'Commerce::Subscribable' do
       end
 
       it 'refunds if argument is true' do
-        allow(product.purchaser).to receive_message_chain('stripe_customer.subscriptions.retrieve.delete')
+        allow(Stripe::Subscription).to receive(:update).with(/^sub_[a-z0-9]{23}$/, { cancel_at_period_end: true })
 
         expect(product).to receive(:refund)
 
@@ -93,7 +93,7 @@ shared_examples_for 'Commerce::Subscribable' do
       end
 
       it 'does not refund if argument is false' do
-        allow(product.purchaser).to receive_message_chain('stripe_customer.subscriptions.retrieve.delete')
+        allow(Stripe::Subscription).to receive(:update).with(/^sub_[a-z0-9]{23}$/, { cancel_at_period_end: true })
 
         expect(product).not_to receive(:refund)
 
@@ -101,8 +101,8 @@ shared_examples_for 'Commerce::Subscribable' do
       end
 
       it 'adds an error to base if Stripe::StripeError is raised while canceling' do
-        allow(product.purchaser)
-          .to receive_message_chain('stripe_customer.subscriptions.retrieve.delete')
+        allow(Stripe::Subscription)
+          .to receive(:update).with(/^sub_[a-z0-9]{23}$/, { cancel_at_period_end: true })
           .and_raise(Stripe::StripeError.new('Message'))
 
         product.cancel


### PR DESCRIPTION
This _seems_ to get stripe subscription behavior back in working order. I don't know about Webhooks—that's a big open question that I'll have to check on before Jan 1. But purchasing and canceling auto-renew memberships seems to work.